### PR TITLE
Sanitize keystore information in the log

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ android {
 
     buildFeatures {
         compose true
+        buildConfig true
     }
 }
 

--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
@@ -53,6 +53,15 @@ class BuildEnvironment(
         }
     }
 
+    private fun sanitizeCommand(cmd: List<String>): String {
+        val cmdString = cmd.toString()
+        val pattern = Regex("""-P(debug|release)_keystore_[a-z_]+=[^,\s\]"]+""")
+        return pattern.replace(cmdString) { matchResult ->
+            val prefix = matchResult.value.substringBefore('=')
+            "$prefix=<REDACTED>"
+        }
+    }
+
     fun executeCommand(
         path: String,
         args: List<String>,
@@ -107,7 +116,9 @@ class BuildEnvironment(
             addAll(args)
         }
 
-        Log.i(TAG, "Cmd: " + cmd.toString())
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "Cmd: " + sanitizeCommand(cmd))
+        }
 
         currentProcess = ProcessBuilder(cmd).apply {
             directory(context.filesDir)

--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironmentService.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironmentService.kt
@@ -132,7 +132,6 @@ class BuildEnvironmentService : Service() {
         var result = 255
 
         if (args != null && projectPath != null && gradleBuildDir != null) {
-            Log.d(TAG, "Received Gradle execute request: ${args} on ${projectPath} / ${gradleBuildDir}")
             result = mBuildEnvironment.executeGradle(args, projectPath, gradleBuildDir, { type, line ->
                 val reply = Message.obtain(null, MSG_COMMAND_OUTPUT, id, type)
                 val replyData = Bundle()


### PR DESCRIPTION
The app is logging the commands it runs for debugging purposes, which, unfortunately, includes the keystore information when running Gradle with a custom keystore

This PR sanitizes that information before logging it

(Another option would be to remove logging this altogether? However, it's been useful for me when working on the app)