### PR TITLE
Set up CI for debug builds and signed releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28b
+
+      - name: Build proot
+        run: |
+          thirdparty/proot/build.sh
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Build debug APK
+        run: |
+          ./gradlew assembleDebug
+
+      - name: Decode keystore
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.KEYSTORE }}" | base64 -d > /tmp/release.keystore
+
+      - name: Build release APK
+        if: github.ref == 'refs/heads/main'
+        env:
+          GABE_RELEASE_KEYSTORE_FILE: /tmp/release.keystore
+          GABE_RELEASE_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          GABE_RELEASE_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          GABE_RELEASE_KEY_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease
+
+      - name: Build release AAB
+        if: github.ref == 'refs/heads/main'
+        env:
+          GABE_RELEASE_KEYSTORE_FILE: /tmp/release.keystore
+          GABE_RELEASE_SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          GABE_RELEASE_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          GABE_RELEASE_KEY_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+        run: |
+          ./gradlew bundleRelease
+
+      - name: Upload debug artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-artifacts
+          path: |
+            app/build/outputs/apk/debug/
+
+      - name: Upload release artifacts
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            app/build/outputs/apk/release/
+            app/build/outputs/bundle/release/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ android {
     compileSdk = 35
     ndkVersion = '28.1.13356709'
 
+    def keystoreFile = System.getenv("GABE_RELEASE_KEYSTORE_FILE")
+
     sourceSets {
         main {
             jniLibs.srcDirs += [
@@ -28,8 +30,22 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    if (keystoreFile != null) {
+        signingConfigs {
+            release {
+                storeFile file(System.getenv("GABE_RELEASE_KEYSTORE_FILE"))
+                storePassword System.getenv("GABE_RELEASE_SIGNING_PASSWORD")
+                keyAlias System.getenv("GABE_RELEASE_KEY_ALIAS")
+                keyPassword System.getenv("GABE_RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            if (keystoreFile != null) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
This PR set up CI builds for GABE.
It first builds proot and then creates a debug apk. If it's pushed to main then it would also create release apk signed by keystore stored in Github Secrets.