### PR TITLE
Add product flavors for the Android and HorizonOS platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,15 @@ jobs:
           GABE_RELEASE_KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           GABE_RELEASE_KEY_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: |
-          ./gradlew assembleRelease bundleRelease
+          ./gradlew assembleRelease bundleAndroidRelease
 
       - name: Upload debug artifacts
         uses: actions/upload-artifact@v4
         with:
           name: debug-artifacts
           path: |
-            app/build/outputs/apk/debug/
+            app/build/outputs/apk/android/debug/
+            app/build/outputs/apk/horizonos/debug/
 
       - name: Upload release artifacts
         if: github.ref == 'refs/heads/main'
@@ -63,5 +64,6 @@ jobs:
         with:
           name: release-artifacts
           path: |
-            app/build/outputs/apk/release/
-            app/build/outputs/bundle/release/
+            app/build/outputs/apk/android/release/
+            app/build/outputs/apk/horizonos/release/
+            app/build/outputs/bundle/androidRelease/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,19 @@ android {
         }
     }
 
+    flavorDimensions = ["android_distribution"]
+    productFlavors {
+        android {
+            dimension "android_distribution"
+            getIsDefault().set(true)
+        }
+        horizonos {
+            dimension "android_distribution"
+            applicationIdSuffix ".horizonos"
+            versionNameSuffix "-horizonos"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
This will allow to leverage platform specific capabilities, permissions and features without affecting the other platforms' binaries.