### PR TITLE
CI: Fix `$ANDROID_NDK_ROOT` to get 16kb aligned pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,16 @@ jobs:
 
       - name: Set up Android NDK
         uses: nttld/setup-ndk@v1
+        id: setup-ndk
         with:
           ndk-version: r29
+          add-to-path: false
 
       - name: Build proot
         run: |
           thirdparty/proot/build.sh
+        env:
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
It appears CI wasn't actually using the NDK version from the `nttld/setup-ndk` (r29) for building proot, but instead the NDK that was already installed on the system (r27), which meant that proot wasn't 16kb aligned