### PR TITLE
Fix invalid project tree copy

### DIFF
--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
@@ -14,6 +14,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStreamReader
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -42,7 +43,7 @@ class BuildEnvironment(private val context: Context, private val rootfs: String,
 
     private val accessLock = ReentrantLock()
     private val accessLockCondition = accessLock.newCondition()
-    @Volatile private var grantedTreeUri: Uri? = null
+    private val grantedTreeUri = AtomicReference<Uri>()
 
     private fun getDefaultEnv(): List<String> {
         return try {
@@ -187,7 +188,7 @@ class BuildEnvironment(private val context: Context, private val rootfs: String,
         }
 
         var projectTreeUri = FileUtils.getProjectTreeUri(context, projectPath)
-        if (projectTreeUri == null) {
+        if (projectTreeUri == null || !FileUtils.isProjectTreeUriPersisted(context, projectTreeUri)) {
             val notificationPerm = checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
             if (notificationPerm == PackageManager.PERMISSION_GRANTED) {
                 outputHandler(
@@ -504,20 +505,22 @@ class BuildEnvironment(private val context: Context, private val rootfs: String,
     fun waitForDirectoryAccess(timeoutMs: Long): Uri? {
         accessLock.withLock {
             var remainingTimeInNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs)
-            while (grantedTreeUri == null && remainingTimeInNanos > 0) {
+            while (grantedTreeUri.get() == null && remainingTimeInNanos > 0) {
                 try {
                     remainingTimeInNanos = accessLockCondition.awaitNanos(remainingTimeInNanos)
                 } catch (_: InterruptedException) {
                     Thread.currentThread().interrupt()
                 }
             }
-            return grantedTreeUri
+            // We reset the value to `null` after returning it to avoid returning a previous value when this method is
+            // invoked again.
+            return grantedTreeUri.getAndSet(null)
         }
     }
 
     fun onDirectoryAccessGranted(uri: Uri) {
         accessLock.withLock {
-            grantedTreeUri = uri
+            grantedTreeUri.set(uri)
             accessLockCondition.signalAll()
         }
     }

--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/FileUtils.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/FileUtils.kt
@@ -177,6 +177,18 @@ object FileUtils {
         prefs.edit { remove(projectPath) }
     }
 
+    /**
+     * Check whether we have persisted the given project tree uri.
+     */
+    fun isProjectTreeUriPersisted(context: Context, projectTreeUri: Uri): Boolean {
+        for (uriPermission in context.contentResolver.persistedUriPermissions) {
+            if (uriPermission.uri == projectTreeUri) {
+                return true
+            }
+        }
+        return false
+    }
+
     fun getProjectTreeUri(context: Context, projectPath: String): Uri? {
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         val uriString = prefs.getString(projectPath, null)


### PR DESCRIPTION
Building a second project after completing the build of the first one without restarting GABE would cause the second build to incorrectly use the project tree uri from the first build, resulting in an invalid binary being generated. 
This is resolved by resetting the value of `grantedTreeUri` after returning it. 

In addition, when retrieving a project tree uri from the shared preferences, we validate that it's still valid before using it.