### PR TITLE
added translation for 2 indian languages hindi & marathi

### DIFF
--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">गोडोट Android बिल्ड एनवायरनमेंट</string>
+    <string name="app_name">"Godot Android Build Environment "</string>
     <string name="app_launcher_name">GABE</string>
     <string name="install_rootfs_button">Rootfs इंस्टॉल करें</string>
     <string name="delete_rootfs_button">Rootfs डिलीट करें</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">गोडोट Android बिल्ड एनवायरनमेंट</string>
+    <string name="app_launcher_name">GABE</string>
+    <string name="install_rootfs_button">Rootfs इंस्टॉल करें</string>
+    <string name="delete_rootfs_button">Rootfs डिलीट करें</string>
+    <string name="installing_rootfs_message">Rootfs इंंस्टॉल हो रहा है...\nइसमें कई मिनट लग सकते हैं।</string>
+    <string name="deleting_rootfs_message">Rootfs हटाया जा रहा है...</string>
+    <string name="missing_rootfs_message">rootfs यह इंस्टॉल नहीं है!\nजब तक आप इसे इंस्टॉल नहीं करते, तब तक आप Gradle बिल्ड नहीं कर पाएंगे।</string>
+    <string name="rootfs_ready_message">लगता है कि Rootfs इंस्टॉल हो गया है!</string>
+    <string name="gradle_build_dir_label">Gradle बिल्ड डायरेक्टरी</string>
+    <string name="notification_perm_request_title">नोटिफ़िकेशन की अनुमति ज़रूरी है</string>
+    <string name="notification_perm_request_message">जब Gradle बिल्ड शुरू होता है, तो आपके प्रोजेक्ट डायरेक्टरी का एक्सेस मांगने के लिए GABE को नोटिफ़िकेशन की अनुमति चाहिए होती है। इसके बिना, बिल्ड आगे नहीं बढ़ सकते।</string>
+    <string name="perm_request_positive_btn">अनुमति दें</string>
+    <string name="perm_request_negative_btn">अभी नहीं</string>
+    <string name="dir_access_notification_channel_name">प्रोजेक्ट एक्सेस</string>
+    <string name="dir_access_notification_channel_description">प्रोजेक्ट डायरेक्टरी तक पहुँचने का अनुरोध</string>
+    <string name="dir_access_notification_title">डायरेक्टरी एक्सेस ज़रूरी है</string>
+    <string name="dir_access_notification_message">प्रोजेक्ट डायरेक्टरी का एक्सेस देने के लिए टैप करें</string>
+</resources>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Godot Android Build Environment</string>
+    <string name="app_launcher_name">GABE</string>
+    <string name="install_rootfs_button">Rootfs स्थापित करा</string>
+    <string name="delete_rootfs_button">Rootfs हटवा</string>
+    <string name="installing_rootfs_message">rootfs स्थापित केले जात आहे...\nयासाठी काही मिनिटे लागू शकतात.</string>
+    <string name="deleting_rootfs_message">rootfs हटवत आहे...</string>
+    <string name="missing_rootfs_message">Rootfs स्थापित (install) केलेले नाही!\nते स्थापित करेपर्यंत तुम्ही Gradle बिल्ड्स करू शकणार नाही.</string>
+    <string name="rootfs_ready_message">Rootfs स्थापित झाल्याचे दिसते!</string>
+    <string name="gradle_build_dir_label">Gradle बिल्ड डिरेक्टरी</string>
+    <string name="notification_perm_request_title">सूचनांची परवानगी आवश्यक आहे</string>
+    <string name="notification_perm_request_message">जेव्हा \'ग्रॅडल बिल्ड\' (Gradle build) सुरू होते, तेव्हा तुमच्या प्रोजेक्ट डिरेक्टरीमध्ये प्रवेश मिळवण्याची विनंती करण्यासाठी GABE ला \'नोटिफिकेशन\' (सूचना) परवान्याची आवश्यकता असते. त्याशिवाय बिल्डची प्रक्रिया पुढे चालू राहू शकत नाही.</string>
+    <string name="perm_request_positive_btn">परवानगी</string>
+    <string name="perm_request_negative_btn">आता नाही</string>
+    <string name="dir_access_notification_channel_name">प्रोजेक्ट प्रवेश</string>
+    <string name="dir_access_notification_channel_description">प्रोजेक्ट निर्देशिकेत प्रवेश करण्याची विनंती करते</string>
+    <string name="dir_access_notification_title">डिरेक्टरी ॲक्सेस आवश्यक आहे</string>
+    <string name="dir_access_notification_message">पप्रोजेक्ट डिरेक्टरीचा ॲक्सेस देण्यासाठी टॅप करा.</string>
+</resources>


### PR DESCRIPTION
translated all of the strings in Hindi ( hi) and Marathi (mr) 
 did everything as instructed actually i used android studio to make changes 
 
 i've kept the technical terms same 
 here's an example:

```
delete Rootfs -> Rootfs डिलीट करें ( Hindi)
delete Rootfs -> Rootfs हटवा ( Marathi)
```

instead of :
```
delete Rootfs -> रूटएफएस  डिलीट करें ( Hindi)
delete Rootfs -> रूटएफएस हटवा ( Marathi)
```

cause developers recognize them as standard identifiers

Related: #37 