### PR TITLE
Add check to validate that the correct directory access has been granted

### DIFF
--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/BuildEnvironment.kt
@@ -207,7 +207,13 @@ class BuildEnvironment(private val context: Context, private val rootfs: String,
 
             projectTreeUri = waitForDirectoryAccess(DIR_ACCESS_WAIT_DURATION)
                 ?: throw Exception("Directory access not granted in time. Build canceled.")
-            outputHandler(OUTPUT_INFO, "Access granted for $projectPath.\nStarting Gradle build...")
+
+            if (!FileUtils.isValidDirSelected(context, projectTreeUri)) {
+                throw Exception("The selected folder is not a valid project directory. Please try exporting again and select $projectPath." +
+                    "\nIf the problem persists, please create a bug report at [color=#3182CE][url]https://github.com/godotengine/android-editor-buildenv-app/issues[/url][/color]")
+            }
+
+            outputHandler(OUTPUT_INFO, "Access granted for project directory. Starting Gradle build...")
             FileUtils.saveProjectTreeUri(context, projectPath, projectTreeUri)
 
             // Notify user if limit is reached so they can clear older projects.

--- a/app/src/main/java/org/godotengine/godot_gradle_build_environment/FileUtils.kt
+++ b/app/src/main/java/org/godotengine/godot_gradle_build_environment/FileUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.DocumentsContract
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import java.io.File
@@ -193,5 +194,13 @@ object FileUtils {
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         val uriString = prefs.getString(projectPath, null)
         return uriString?.toUri()
+    }
+
+    fun isValidDirSelected(context: Context, projectTreeUri: Uri): Boolean {
+        val treeDocumentId = DocumentsContract.getTreeDocumentId(projectTreeUri) ?: return false
+        // Check if "project.godot" file exists.
+        val projectGodotUri = DocumentsContract.buildDocumentUriUsingTree(projectTreeUri, "$treeDocumentId/project.godot")
+        val godotFile = DocumentFile.fromSingleUri(context, projectGodotUri)
+        return godotFile?.exists() == true
     }
 }


### PR DESCRIPTION
This only checks whether the selected directory contains a `project.godot` file. It helps catch cases where the user selects a non-Godot directory, such as the parent directory of the project or one of its subdirectories.

It won't detect if the user selects a _different_ project, but the chances of accidentally selecting another project's directory is low.

Unfortunately, we don't have much options here to validate this due to Android OS limitations.

closes #30 